### PR TITLE
update to 0.7 Random API

### DIFF
--- a/src/extras/random.jl
+++ b/src/extras/random.jl
@@ -1,7 +1,7 @@
 using Random
 import Random.rand
 
-function rand(rng::AbstractRNG, S::Type{DoubleFloat{T}}) where {T<:IEEEFloat}
+function rand(rng::AbstractRNG, ::Random.SamplerTrivial{Random.CloseOpen01{DoubleFloat{T}}}) where {T<:IEEEFloat}
     u  = rand(rng, UInt64)
     f  = Float64(u)
     uf = UInt64(f)
@@ -10,22 +10,3 @@ function rand(rng::AbstractRNG, S::Type{DoubleFloat{T}}) where {T<:IEEEFloat}
 
     DoubleFloat(T(5.421010862427522e-20 * f), T(5.421010862427522e-20 * rf))
 end
-
-rand(::Type{DoubleFloat{T}}) where {T<:AbstractFloat} =
-    rand(Random.GLOBAL_RNG, DoubleFloat{T})
-
-for T in (:Float64, :Float32, :Float16)
-  @eval begin
-        
-    function rand(::Type{DoubleFloat{$T}}, n::Int)
-        rs = Array{DoubleFloat{$T}}(undef, n)
-        for idx=1:n
-            rs[idx] = rand(DoubleFloat{$T})
-        end
-        return rs
-    end
-        
-  end
-end
-
-rand(::Type{DoubleFloat}, n::Int) = rand(DoubleFloat{Float64}, n)


### PR DESCRIPTION
This uses the API described at https://github.com/JuliaLang/julia/pull/27983 to hook into the `rand` machinery.
This is less code and more functionality, e.g. now `rand!(rand(Double64, 3))` works, as well as `rand(Double64, Int8(3))`, etc.
