### PR TITLE
Add Base.precision

### DIFF
--- a/src/Double.jl
+++ b/src/Double.jl
@@ -114,3 +114,7 @@ const hash_0_double_lo = hash(zero(UInt), hash_double_lo)
 
 @inline Base.hash(z::DoubleFloat{T}, h::UInt) where {F<:IEEEFloat, G<:DoubleFloat{F}, T<:DoubleFloat{G}} =
     hash(z.hi) ⊻ hash(z.lo)
+
+Base.precision(::Double64) = 113
+Base.precision(::Double32) = 53
+Base.precision(::Double16) = 24

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1,0 +1,5 @@
+@testset "Basics" begin
+    @test precision(Double64) == 113
+    @test precision(Double32) == 53
+    @test precision(Double32) == 24
+end


### PR DESCRIPTION
I noticed that `Base.precision` is missing, which should return the length of the mantissa. I was not completely sure which values are correct, so I ended up with just choosing the IEEE mantissa lengths. These are probably slightly off, so if you @JeffreySarnoff can tell me the correct numbers I will change them happily. But I think these numbers should be the theoretical accuracy and not the worst accuracy for any of the special function implemented.