### PR TITLE
Add `add`, `div`, `sub`, `mul` to avoid unnecessary conversions

### DIFF
--- a/src/DoubleFloats.jl
+++ b/src/DoubleFloats.jl
@@ -10,7 +10,9 @@ export DoubleFloat,
        isposinf, isneginf, isfractional,
        nan, inf, posinf, neginf,
        intpart, fracpart, fmod,
-       square, cube
+       square, cube,
+       add2, sub2, mul2, div2,
+       ⊕, ⊖, ⊗, ⊘
        #spread, sld, tld,
        #signs
 

--- a/src/math/ops/arith.jl
+++ b/src/math/ops/arith.jl
@@ -1,5 +1,3 @@
-
-
 abs(x::DoubleFloat{T}) where {T<:AbstractFloat} = abs_db_db(x)
 (-)(x::DoubleFloat{T}) where {T<:AbstractFloat} = neg_db_db(x)
 negabs(x::DoubleFloat{T}) where {T<:AbstractFloat} = negabs_db_db(x)
@@ -26,3 +24,74 @@ cbrt(x::DoubleFloat{T}) where {T<:AbstractFloat} = cbrt_db_db(x)
 (/)(x::T, y::DoubleFloat{T}) where {T<:AbstractFloat} = dvi_fpdb_db(x, y)
 (/)(x::DoubleFloat{T}, y::T) where {T<:AbstractFloat} = dvi_dbfp_db(x, y)
 (/)(x::DoubleFloat{T}, y::DoubleFloat{T}) where {T<:AbstractFloat} = dvi_dbdb_db(x, y)
+
+# Also provide arithmetic to add two floating point numbers in a higher precision
+# without first converting them
+"""
+    add2(x::T, y::T) where {T<:AbstractFloat}
+
+Add `x` and `y` as if they are `DoubleFloat{T}` numbers. This is more
+efficient as first converting to `DoubleFloat{T}` and then adding.
+"""
+add2(x::T, y::T) where {T<:AbstractFloat} = add_fpfp_db(x, y)
+
+"""
+    ⊕(x::T, y::T) where {T<:AbstractFloat}
+
+Add `x` and `y` as if they are `DoubleFloat{T}` numbers. This is more
+efficient as first converting to `DoubleFloat{T}` and then adding.
+This is the inline version of [`add2`](@ref) and written as ``\\oplus``.
+"""
+⊕(x::T, y::T) where {T<:AbstractFloat} = add2(x, y)
+
+
+"""
+    sub2(x::T, y::T) where {T<:AbstractFloat}
+
+Subtract `x` and `y` as if they are `DoubleFloat{T}` numbers. This is more
+efficient as first converting to `DoubleFloat{T}` and then subtracting.
+"""
+sub2(x::T, y::T) where {T<:AbstractFloat} = sub_fpfp_db(x, y)
+
+"""
+    ⊖(x::T, y::T) where {T<:AbstractFloat}
+
+Subtract `x` and `y` as if they are `DoubleFloat{T}` numbers. This is more
+efficient as first converting to `DoubleFloat{T}` and then subtracting.
+This is the inline version of [`sub2`](@ref) and written as `\\ominus`.
+"""
+⊖(x::T, y::T) where {T<:AbstractFloat} = sub2(x, y)
+
+"""
+    mul2(x::T, y::T) where {T<:AbstractFloat}
+
+Multiply `x` and `y` as if they are `DoubleFloat{T}` numbers. This is more
+efficient as first converting to `DoubleFloat{T}` and then multiplying.
+"""
+mul2(x::T, y::T) where {T<:AbstractFloat} = mul_fpfp_db(x, y)
+
+"""
+    ⊗(x::T, y::T) where {T<:AbstractFloat}
+
+Multiply `x` and `y` as if they are `DoubleFloat{T}` numbers. This is more
+efficient as first converting to `DoubleFloat{T}` and then multiplying.
+This is the inline version of [`mul2`](@ref) and written as `\\otimes`.
+"""
+⊗(x::T, y::T) where {T<:AbstractFloat} = mul2(x, y)
+
+"""
+    div(x::T, y::T) where {T<:AbstractFloat}
+
+Divide `x` and `y` as if they are `DoubleFloat{T}` numbers. This is more
+efficient as first converting to `DoubleFloat{T}` and then dividing.
+"""
+div2(x::T, y::T) where {T<:AbstractFloat} = dvi_fpfp_db(x, y)
+
+"""
+    ⊘(x::T, y::T) where {T<:AbstractFloat}
+
+Divide `x` and `y` as if they are `DoubleFloat{T}` numbers. This is more
+efficient as first converting to `DoubleFloat{T}` and then dividing.
+This is the inline version of [`div2`](@ref) and written as ``\\oslash``.
+"""
+⊘(x::T, y::T) where {T<:AbstractFloat} = div2(x, y)

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -14,6 +14,17 @@
     @test y ^ x isa Complex{Double64}
     @test x ^ x isa Complex{Double64}
     @test y ^ y isa Double64
+
+    x, y = rand(2)
+    @test add2(x, y) == (Double64(x) + Double64(y))
+    @test sub2(x, y) == (Double64(x) - Double64(y))
+    @test mul2(x, y) == (Double64(x) * Double64(y))
+    @test div2(x, y) == (Double64(x) / Double64(y))
+
+    @test x ⊕ y == (Double64(x) + Double64(y))
+    @test x ⊖ y == (Double64(x) - Double64(y))
+    @test x ⊗ y == (Double64(x) * Double64(y))
+    @test x ⊘ y == (Double64(x) / Double64(y))
 end
 
 @testset "Trig functions" begin


### PR DESCRIPTION
This adds the functions`add`, `div`, `sub`, `mul` which take two floats `T` and return `DoubleFloat{T}`. This is more efficient than first converting to `DoubleFloat{T}` and then doing the arithmetic operation.
```julia
julia> x, y = rand(2);

julia> @btime add($x, $y)
  2.170 ns (0 allocations: 0 bytes)
1.0350040076190325510907541683991439

julia> @btime Double64($x) + Double64($y)
  5.788 ns (0 allocations: 0 bytes)
1.0350040076190325510907541683991439
```