### PR TITLE
Catch Inf and NaN generation

### DIFF
--- a/src/Double.jl
+++ b/src/Double.jl
@@ -66,19 +66,19 @@ const QuadrupleF16 = DoubleFloat{DoubleFloat{Float16}}
 @inline DoubleFloat(x::Tuple{T,T}) where {T<:AbstractFloat} = DoubleFloat{T}(x[1], x[2])
 
 @inline function Double64(x::T) where {T<:IEEEFloat}
-    !isfinite(x) && return(Double64(Float64(x),zero(T)))
+    !isfinite(x) && return(DoubleFloat(Float64(x),Float64(NaN)))
     hi = Float64(x)
     lo = Float64(x - Float64(hi))
     return Double64(hi, lo)
 end
 @inline function Double32(x::T) where {T<:IEEEFloat}
-    !isfinite(x) && return(Double32(Float32(x),zero(T)))
+    !isfinite(x) && return(DoubleFloat(Float32(x),Float32(NaN)))
     hi = Float32(x)
     lo = Float32(x - Float64(hi))
     return Double32(hi, lo)
 end
 @inline function Double16(x::T) where {T<:IEEEFloat}
-    !isfinite(x) && return(Double16(Float16(x),zero(T)))
+    !isfinite(x) && return(DoubleFloat(Float16(x),Float16(NaN)))
     hi = Float16(x)
     lo = Float16(x - Float64(hi))
     return Double16(hi, lo)

--- a/src/DoubleFloats.jl
+++ b/src/DoubleFloats.jl
@@ -51,7 +51,7 @@ using Random
 
 using AccurateArithmetic
 
-include("Double.jl")   # Double64, Double16, Double16
+include("Double.jl")   # Double64, Double32, Double16
 
 include("doubletriple/double.jl")
 include("doubletriple/double_consts.jl")

--- a/test/specialvalues.jl
+++ b/test/specialvalues.jl
@@ -12,7 +12,6 @@ end
 
 
 @testset "Inf and NaN generation $T" for T in (Double16, Double32, Double64)
-
     @test T(Inf) == inf(T)
     @test T(Inf) == posinf(T)
     @test T(-Inf) == neginf(T)

--- a/test/specialvalues.jl
+++ b/test/specialvalues.jl
@@ -12,8 +12,19 @@ end
 
 
 @testset "Inf and NaN generation $T" for T in (Double16, Double32, Double64)
+
     @test T(Inf) == inf(T)
     @test T(Inf) == posinf(T)
     @test T(-Inf) == neginf(T)
     @test T(NaN) == nan(T)
+
+    @test T(Inf32) == inf(T)
+    @test T(Inf32) == posinf(T)
+    @test T(-Inf32) == neginf(T)
+    @test T(NaN32) == nan(T)
+
+    @test T(Inf16) == inf(T)
+    @test T(Inf16) == posinf(T)
+    @test T(-Inf16) == neginf(T)
+    @test T(NaN16) == nan(T)
 end

--- a/test/specialvalues.jl
+++ b/test/specialvalues.jl
@@ -9,3 +9,11 @@ end
 # Double16 is a special case
 @test isinteger(maxintfloat(Double16))
 @test maxintfloat(Double16) == floatmax(Double16)
+
+
+@testset "Inf and NaN generation $T" for T in (Double16, Double32, Double64)
+    @test T(Inf) == inf(T)
+    @test T(Inf) == posinf(T)
+    @test T(-Inf) == neginf(T)
+    @test T(NaN) == nan(T)
+end


### PR DESCRIPTION
Fixes #19 

This change makes `T(Inf)`, `T(-Inf)`, and `T(NaN)` behave like `inf(T)`, `neginf(T)`, and `nan(T)`, which I hope is the behaviour we want?