### PR TITLE
Fix docs and code coverage setup + enable Codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,24 @@ julia:
   - nightly
 matrix:
   fast_finish: true
-#  allow_failures:
-#    - julia: nightly
+
+ allow_failures:
+   - julia: nightly
+
 notifications:
   email: false
 git:
   depth: 99999999
-## uncomment the following lines to override the default test script
-#script:
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("DoubleFloats"); Pkg.test("DoubleFloats"; coverage=true)'
+
+jobs:
+  include:
+    - stage: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.add(PackageSpec(path=pwd()))'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip
+
 after_success:
-  - julia -e 'Pkg.add("Documenter"); using Documenter;'
-  - julia -e 'cd(Pkg.dir("DoubleFloats")); include(joinpath("docs", "make.jl"))'
-  - julia -e 'cd(Pkg.dir("DoubleFloats")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
- 
+  - julia -e import Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder());'

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "^0.19.6"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,7 +17,6 @@ makedocs(
 )
 
 deploydocs(
-    julia = "nightly",
+    julia = "1.0",
     repo = "github.com/JuliaMath/DoubleFloats.jl.git"
 )
-


### PR DESCRIPTION
Triggered by #23 I wanted to check the code coverage of DoubleFloats, and noticed that this doesn't exists... So this should push the current coverage to Coveralls and Codecov.

I also noticed that the docs didn't built anymore. Now CI fails if the docs cannot be build.