### PR TITLE
prevent domain exception in basic rand(::DoubleFloat) method

### DIFF
--- a/src/extras/random.jl
+++ b/src/extras/random.jl
@@ -3,6 +3,9 @@ import Random.rand
 
 function rand(rng::AbstractRNG, ::Random.SamplerTrivial{Random.CloseOpen01{DoubleFloat{T}}}) where {T<:IEEEFloat}
     hi, lo  = rand(rng, T, 2)
+    while hi == zero(T) # fairly common with Float16 or Float32
+        hi = rand(rng, T)
+    end
     frlo, xplo  = frexp(lo)
     xplo = Base.exponent(hi) - min(1, fld(xplo,4)) - abs(Base.exponent(eps(hi)))
     lo = ldexp(frlo, xplo)

--- a/test/coverage.jl
+++ b/test/coverage.jl
@@ -190,3 +190,16 @@ end # compare
     @test nextfloat(fp2,3) > nextfloat(fp2,2)
     @test prevfloat(fp2,3) < prevfloat(fp2,2)
 end
+
+@testset "random Double16" begin
+    rng = Random.MersenneTwister()
+    Random.seed!(rng, 1103)
+    T = Float16
+    DT = DoubleFloat{T}
+    # first make sure we don't throw when sample(T) is 0
+    a = rand(rng,DT,2^(precision(T)+2))
+
+    # This takes a few seconds.
+    # a = rand(rng,DT,2^(precision(DT)+2))
+    # @test_broken count(a .== zero(T)) > 0
+end


### PR DESCRIPTION
Since the range of the underlying rand(::Float) is the
left-closed unit interval, zeroes arise occasionally, so
we must protect the Base.exponent() call.