### PR TITLE
Inplace matmul

### DIFF
--- a/src/math/linearalgebra/matmul.jl
+++ b/src/math/linearalgebra/matmul.jl
@@ -1,75 +1,75 @@
 """
-    *(a, b)
+    mul!(c, a, b)
 
-A more performant version of `a * b` where a, b are matrices
+A more performant version of `c = a * b` where a, b, c are matrices
 """
-function Base.:(*)(a::Array{DoubleFloat{T},2}, b::Array{DoubleFloat{T},2}) where {T<:AbstractFloat}
+function LinearAlgebra.mul!(c::Array{DoubleFloat{T},2}, a::Array{DoubleFloat{T},2}, b::Array{DoubleFloat{T},2}) where {T<:AbstractFloat}
     arows, acols = size(a)
     brows, bcols = size(b)
     if  acols != brows
         throw(DimensionMismatch(string("size(a,1) != size(b,2): ",size(a,1), " != ", size(b,2))))
     end
+    if size(c,1) != arows || size(c,2) != bcols
+        throw(DimensionMismatch("result c has dimensions $(size(c)), needs ($arows,$bcols)"))
+    end
 
-    result_rows, result_cols = arows, bcols
-    result = reshape(Array{DoubleFloat{T}, 1}(undef, result_rows*result_cols), (result_rows, result_cols))
-
-    for bcol = 1:bcols
+    @inbounds for bcol = 1:bcols
         for arow=1:arows
             asum = zero(DoubleFloat{T})
             for acol=1:acols
                 @inbounds asum = fma(a[arow,acol], b[acol,bcol], asum)
             end
-            @inbounds result[arow,bcol] = asum
+            @inbounds c[arow,bcol] = asum
         end
     end
 
-    return result
+    return c
 end
 
 
-function Base.:(*)(a::Array{DoubleFloat{T},2}, b::Array{T,2}) where {T<:AbstractFloat}
+function LinearAlgebra.mul!(c::Array{DoubleFloat{T},2}, a::Array{DoubleFloat{T},2}, b::Array{T,2}) where {T<:AbstractFloat}
     arows, acols = size(a)
     brows, bcols = size(b)
     if  acols != brows
         throw(DimensionMismatch(string("size(a,1) != size(b,2): ",size(a,1), " != ", size(b,2))))
     end
+    if size(c,1) != arows || size(c,2) != bcols
+        throw(DimensionMismatch("result c has dimensions $(size(c)), needs ($arows,$bcols)"))
+    end
 
-    result_rows, result_cols = arows, bcols
-    result = reshape(Array{DoubleFloat{T}, 1}(undef, result_rows*result_cols), (result_rows, result_cols))
-
-    for bcol = 1:bcols
+    @inbounds for bcol = 1:bcols
         for arow=1:arows
             asum = zero(DoubleFloat{T})
             for acol=1:acols
                 @inbounds asum = fma(a[arow,acol], b[acol,bcol], asum)
             end
-            @inbounds result[arow,bcol] = asum
+            @inbounds c[arow,bcol] = asum
         end
     end
 
-    return result
+    return c
 end
 
 
-function Base.:(*)(a::Array{T,2}, b::Array{DoubleFloat{T},2}) where {T<:AbstractFloat}
+function LinearAlgebra.mul!(c::Array{DoubleFloat{T},2}, a::Array{T,2}, b::Array{DoubleFloat{T},2}) where {T<:AbstractFloat}
     arows, acols = size(a)
     brows, bcols = size(b)
     if  acols != brows
         throw(DimensionMismatch(string("size(a,1) != size(b,2): ",size(a,1), " != ", size(b,2))))
     end
+    if size(c,1) != arows || size(c,2) != bcols
+        throw(DimensionMismatch("result c has dimensions $(size(c)), needs ($arows,$bcols)"))
+    end
 
-    result_rows, result_cols = arows, bcols
-    result = reshape(Array{DoubleFloat{T}, 1}(undef, result_rows*result_cols), (result_rows, result_cols))
-
-    for bcol = 1:bcols
+    @inbounds for bcol = 1:bcols
         for arow=1:arows
             asum = zero(DoubleFloat{T})
             for acol=1:acols
                 @inbounds asum = fma(a[arow,acol], b[acol,bcol], asum)
             end
-            @inbounds result[arow,bcol] = asum
+            @inbounds c[arow,bcol] = asum
         end
     end
 
-    return result
+    return c
 end

--- a/src/math/linearalgebra/matmul.jl
+++ b/src/math/linearalgebra/matmul.jl
@@ -13,7 +13,7 @@ function LinearAlgebra.mul!(c::Array{DoubleFloat{T},2}, a::Array{DoubleFloat{T},
         throw(DimensionMismatch("result c has dimensions $(size(c)), needs ($arows,$bcols)"))
     end
 
-    @inbounds for bcol = 1:bcols
+    for bcol = 1:bcols
         for arow=1:arows
             asum = zero(DoubleFloat{T})
             for acol=1:acols
@@ -37,7 +37,7 @@ function LinearAlgebra.mul!(c::Array{DoubleFloat{T},2}, a::Array{DoubleFloat{T},
         throw(DimensionMismatch("result c has dimensions $(size(c)), needs ($arows,$bcols)"))
     end
 
-    @inbounds for bcol = 1:bcols
+    for bcol = 1:bcols
         for arow=1:arows
             asum = zero(DoubleFloat{T})
             for acol=1:acols
@@ -61,7 +61,7 @@ function LinearAlgebra.mul!(c::Array{DoubleFloat{T},2}, a::Array{T,2}, b::Array{
         throw(DimensionMismatch("result c has dimensions $(size(c)), needs ($arows,$bcols)"))
     end
 
-    @inbounds for bcol = 1:bcols
+    for bcol = 1:bcols
         for arow=1:arows
             asum = zero(DoubleFloat{T})
             for acol=1:acols

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -21,6 +21,11 @@
     # Incompatible Dimension
     @test_throws DimensionMismatch Double64.(B1)*Double64.(A1)
 
+    # Test in-place multiplication
+    C1 = Array{Double64,2}(undef, 3, 2)
+    C1out = LinearAlgebra.mul!(C1, A1, B1)
+    @test C1 == A1B1
+    @test C1 === C1out
 
     #Test with zero inner dimension (zero result)
     A2 = Array{Float64,2}(undef, 2, 0)
@@ -38,6 +43,11 @@
     @test DA2FB2 isa Array{Double64,2}
     @test FA2DB2 isa Array{Double64,2}
 
+    # Test in-place multiplication
+    C2 = Array{Double64,2}(undef, 2, 3)
+    C2out = LinearAlgebra.mul!(C2, A2, B2)
+    @test C2 == A2B2
+    @test C2 === C2out
 
     #Test with zero outer dimensions (empty result)
     A3 = Array{Float64,2}(undef, 0, 3)
@@ -55,5 +65,10 @@
     @test DA3FB3 isa Array{Double64,2}
     @test FA3DB3 isa Array{Double64,2}
 
+    # Test in-place multiplication
+    C3 = Array{Double64,2}(undef, 0, 0)
+    C3out = LinearAlgebra.mul!(C3, A3, B3)
+    @test C3 == A3B3
+    @test C3 === C3out
 
 end


### PR DESCRIPTION
Implements inplace matrix multiplication through the `mul!`interface according to discussion in https://github.com/JuliaMath/DoubleFloats.jl/pull/46

This PR allows usage of 
`mul!(C,A,B)` in an efficient way instead of relying on
`C=A*B`.

The way `C=A*B` is handled after this change is though the standard library
 https://github.com/JuliaLang/julia/blob/master/stdlib/LinearAlgebra/src/matmul.jl#L140
```julia
function (*)(A::AbstractMatrix, B::AbstractMatrix)
    TS = promote_op(matprod, eltype(A), eltype(B))
    mul!(similar(B, TS, (size(A,1), size(B,2))), A, B)
end
```
which calles the code in this PR.
I.e. the output matrix will be allocated and then `mul!(C, A, B)` is called.
The same operations are thus made through dispatch, but we now allow to directly use `mul!(C,A,B)` to avoid allocations. I think this would be the canonical way of implementing matrix multiplication in julia, since we do not(?) want to rely on the generic fallback
```julia
mul!(C::AbstractMatrix, A::AbstractVecOrMat, B::AbstractVecOrMat) = generic_matmatmul!(C, 'N', 'N', A, B)
```