### PR TITLE
Remove unnecessary conversion to BigFloat in convert

### DIFF
--- a/src/type/convert.jl
+++ b/src/type/convert.jl
@@ -22,7 +22,7 @@ function convert(::Type{DoubleFloat{T}}, x::BigFloat) where {T<:IEEEFloat}
     lo = T(x - hi)
     return DoubleFloat(hi, lo)
 end
-  
+
 function convert(::Type{BigInt}, x::DoubleFloat{T}) where {T<:IEEEFloat}
     res = round(Base.BigInt, Base.BigFloat(HI(x)) + Base.BigFloat(LO(x)))
     return res
@@ -38,9 +38,10 @@ convert(::Type{T}, x::DoubleFloat{DoubleFloat{T}}) where {T<:IEEEFloat} = HI(HI(
 convert(::Type{DoubleFloat{DoubleFloat{T}}}, x::T) where {T<:IEEEFloat} = DoubleFloat(DoubleFloat{T}(x), DoubleFloat{T}(zero(T)))
 
 convert(::Type{DoubleFloat{T}}, x::Tuple{T,T}) where {T<:IEEEFloat} = DoubleFloat{T}(x[1],x[2])
- 
+
 convert(::Type{Complex{Double64}}, x::T) where {T<:AbstractIrrational} = Complex(Double64(x))
 convert(::Type{Complex{Double32}}, x::T) where {T<:AbstractIrrational} = Complex(Double32(x))
 convert(::Type{Complex{Double16}}, x::T) where {T<:AbstractIrrational} = Complex(Double16(x))
 
 convert(::Type{DoubleFloat{T}}, x::Real) where {T<:IEEEFloat} = DoubleFloat{T}(BigFloat(x))
+convert(::Type{DoubleFloat{T}}, x::IEEEFloat) where {T<:IEEEFloat} = DoubleFloat{T}(x)

--- a/test/coverage.jl
+++ b/test/coverage.jl
@@ -1,27 +1,40 @@
 @testset "convert" begin
 
-one = 1
-bf = BigFloat(pi)
-df = Double64(bf)
-sqrt2 = sqrt(2.0)
+    one = 1
+    bf = BigFloat(pi)
+    df = Double64(bf)
+    sqrt2 = sqrt(2.0)
 
-@test BigFloat(df) == convert(BigFloat, df)
-@test Double64(bf) == convert(Double64, bf)
+    @test BigFloat(df) == convert(BigFloat, df)
+    @test Double64(bf) == convert(Double64, bf)
 
-@test Double32(sqrt2) == convert(Double32, sqrt2)
-@test Double64(sqrt2) == convert(Double64, sqrt2)
+    @test Double32(sqrt2) == convert(Double32, sqrt2)
+    @test Double64(sqrt2) == convert(Double64, sqrt2)
 
-@test one == convert(Int, Double64(1))
-@test BigInt(one) == convert(BigInt, Double32(1))
-@test Double16(1) == convert(Double16, BigInt(1))
+    @test one == convert(Int, Double64(1))
+    @test BigInt(one) == convert(BigInt, Double32(1))
+    @test Double16(1) == convert(Double16, BigInt(1))
 
+    x = rand()
+    @test convert(Double64, x) isa Double64
+    allocs = @allocated convert(Double64, x)
+    @test allocs == 0
+
+    x32 = rand(Float32)
+    allocs32 = @allocated convert(Double64, x32)
+    @test allocs32 == 0
+
+    z = rand(ComplexF64)
+    @test convert(ComplexDF64, z) isa ComplexDF64
+    allocs = @allocated convert(ComplexDF64, z)
+    @test allocs == 0
 end # convert
 
 @testset "construct $T" for T in (Double16, Double32, Double64)
-    
+
     i5 = 5
     five = T(5)
-    
+
     @test Int64(i5) == Int64(five)
     @test Int32(i5) == Int32(five)
     @test Int16(i5) == Int16(five)
@@ -30,7 +43,7 @@ end # convert
     @test Float16(i5) == Float16(five)
     @test five == T(BigFloat(i5))
     @test five == T(BigInt(i5))
-    
+
     @test five == T(five)
     @test five == T(T(five))
 end
@@ -44,7 +57,7 @@ end
 end
 
 @testset "predicates $T" for T in (Double16, Double32, Double64)
-  
+
     @test iszero(zero(T))
     @test isone(one(T))
     @test ispositive(one(T))
@@ -53,16 +66,16 @@ end
     @test isnonpositive(zero(T))
     @test isnonnegative(one(T))
     @test isnonnegative(zero(T))
-  
+
     @test isinf(T(Inf))
     @test isposinf(T(Inf))
     @test isneginf(T(-Inf))
     @test isnan(T(NaN))
-  
+
     @test isnormal(one(T))
     @test isinteger(one(T))
     @test isfractional(one(T)/2)
-  
+
 end # predicates
 
 @testset "double $T" for T in (Double16, Double32, Double64)
@@ -70,19 +83,19 @@ end # predicates
     @test HI(one(T)) == one(T)
     @test LO(one(T)) == zero(T)
     @test HILO(one(T)) == (one(T), zero(T))
-    
+
     sqrt2  = sqrt(T(2))
     hi, lo = sqrt2.hi, sqrt2.lo
     hilo   = HILO(sqrt2)
-    
+
     @test HI(sqrt2) == hi
     @test LO(sqrt2) == lo
     @test HILO(sqrt2) == (hi, lo)
-    
+
     @test HI(hilo) == hi
     @test LO(hilo) == lo
     @test HILO(hilo) == hilo
-        
+
 end # Double
 
 @testset "compare $T" for T in (Double16, Double32, Double64)
@@ -93,10 +106,10 @@ end # Double
     fp2 = T(2)
     sqrt2  = sqrt(T(2))
     sqrt5  = sqrt(T(5))
-    
+
     @test isequal(sqrt2, sqrt2)
     @test isless(sqrt2, sqrt5)
-    
+
     @test sqrt5 != two
     @test two != sqrt5
     @test two == fp2
@@ -122,7 +135,7 @@ end # Double
     @test sqrt5 > one
     @test !(one >= sqrt5)
     @test sqrt5 >= one
-        
+
     @test   sqrt2 == sqrt2
     @test   sqrt2 >= sqrt2
     @test   sqrt2 <= sqrt2
@@ -163,8 +176,8 @@ end # Double
     @test   sqrt5 >= two
     @test   sqrt5 != two
     @test !(sqrt5 <  two)
-    @test   sqrt5 >  two    
-    
+    @test   sqrt5 >  two
+
 end # compare
 
 @testset "eps $T" for T in (Double16, Double32, Double64)
@@ -173,22 +186,22 @@ end # compare
 
     @test eps(fp2) >= DoubleFloats.ulp(fp2)
     @test eps(sqrt2) >= DoubleFloats.ulp(sqrt2)
-    
+
     @test nextfloat(fp2) > fp2
     @test nextfloat(sqrt2) > sqrt2
-    
+
     @test prevfloat(fp2) < fp2
     @test prevfloat(sqrt2) < sqrt2
-    
+
     @test nextfloat(-fp2) > -fp2
     @test nextfloat(-sqrt2) > -sqrt2
-    
+
     @test prevfloat(-fp2) < -fp2
     @test prevfloat(-sqrt2) < -sqrt2
-    
+
     @test nextfloat(fp2,2) > fp2
     @test nextfloat(sqrt2,2) > sqrt2
-    
+
     @test nextfloat(fp2,3) > nextfloat(fp2,2)
     @test prevfloat(fp2,3) < prevfloat(fp2,2)
 end


### PR DESCRIPTION
Previously
```
x = rand()
convert(Double64, x) 
```
allocated since it (unnecessarily) first converted `x` to a `BigFloat`.