### PR TITLE
Tests for complex norms

### DIFF
--- a/src/math/linearalgebra/support.jl
+++ b/src/math/linearalgebra/support.jl
@@ -24,7 +24,7 @@ function norm(v::Array{Complex{DoubleFloat{T}},N}, p::Real=2.0) where {N, T<:IEE
     if isinf(p)
         return signbit(p) ? minimum(abs.(real.(v))) : maximum(abs.(real.(v)))
     elseif p==2
-        return vp = sqrt(sum(conj.(v) .* v))
+        return vp = sqrt(real(sum(conj.(v) .* v)))
     else    
         vp = sum(abs.(v).^(p))
         r = inv(DoubleFloat{T}(p))

--- a/test/linearalgebra.jl
+++ b/test/linearalgebra.jl
@@ -10,4 +10,13 @@
     t=[Complex{Double64}(1.0,0.0) Complex{Double64}(0.0,1.0);
        Complex{Double64}(0.0,-1.0) Complex{Double64}(1.0,0.0)]
     @test ishermitian(t)
+
+    @test norm(Complex{Double64}[2, 2im]) ≈ norm(ComplexF64[2, 2im])
+    @test norm(Complex{Double64}[2, 2im]) isa Double64
+
+    @test norm(Complex{Double64}[2, 2im], 3.0) ≈ norm(ComplexF64[2, 2im], 3.0)
+    @test norm(Complex{Double64}[2, 2im], 3.0) isa Double64
+
+    @test norm(Double64[2, 1]) ≈ norm(Float64[2, 1])
+    @test norm(Double64[2, 1], 3.0) ≈ norm(Float64[2, 1], 3.0)
 end


### PR DESCRIPTION
Sorry @JeffreySarnoff I missed in my first fix, that the complex norm function also returns the wrong type for 2-norms (namely e.g. `Complex{Double64}`, where a real type should be returned). So I made some small tests, just to be sure for next time ...