### PR TITLE
remove GenericSVD and GenericSchur as dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,8 +23,10 @@ SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1.0, 1.1"
 julia = "1"
 
 [extras]
+GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
+GenericSchur = "c145ed77-6b09-5dd9-b285-bf645a82121e"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SpecialFunctions"]
+test = ["Test", "SpecialFunctions", "GenericLinearAlgebra", "GenericSchur"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,6 @@ repo = "https://github.com/JuliaMath/DoubleFloats.jl.git"
 version = "1.1.18"
 
 [deps]
-GenericSVD = "01680d73-4ee2-5a08-a1aa-533608c188bb"
-GenericSchur = "c145ed77-6b09-5dd9-b285-bf645a82121e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -18,8 +16,6 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-GenericSVD = "0.3, 0.4, 0.5"
-GenericSchur = "0.3, 0.4, 0.5"
 Polynomials = "1, 2"
 Quadmath = "0.4, 0.5, 0.6"
 Requires = "1"

--- a/docs/src/linearalgebra.md
+++ b/docs/src/linearalgebra.md
@@ -3,13 +3,13 @@
 ## Using
 
 ```julia
-using DoubleFloats, GenericSchur, GenericSVD, LinearAlgebra
+using DoubleFloats, LinearAlgebra
 ```
 
 ## Vectors and Matrices
 
 ```julia
-using DoubleFloats, GenericSchur, GenericSVD, LinearAlgebra
+using DoubleFloats, LinearAlgebra
 
 n = 25
 vector = rand(Double64, n)

--- a/src/DoubleFloats.jl
+++ b/src/DoubleFloats.jl
@@ -43,7 +43,6 @@ import Random: rand, randn
 
 using Polynomials
 
-using GenericSVD, GenericSchur
 using LinearAlgebra
 import LinearAlgebra: norm, mul!
 

--- a/test/linearalgebra.jl
+++ b/test/linearalgebra.jl
@@ -1,3 +1,5 @@
+using GenericLinearAlgebra, GenericSchur
+
 @testset "linear algebra" begin
     @test issquare(reshape(rand(Double32,3*3), 3, 3))
 


### PR DESCRIPTION
Due to type piracy, these packages cause problems with precompilation and don't play nice with GenericLinearAlgebra (see discussion in https://github.com/JuliaLinearAlgebra/GenericLinearAlgebra.jl/pull/71). Additionally, GenericSVD has now been deprecated (https://github.com/JuliaLinearAlgebra/GenericSVD.jl/issues/30).