### PR TITLE
Remove ini_hex, ini_HEX

### DIFF
--- a/src/type/show.jl
+++ b/src/type/show.jl
@@ -1,4 +1,4 @@
-import Printf: ini_dec, fix_dec, ini_hex, ini_HEX
+import Printf: ini_dec, fix_dec
 
 show(io::IO, ::Type{Double64}) = print(io, "Double64")
 show(io::IO, ::Type{Double32}) = print(io, "Double32")


### PR DESCRIPTION
When precompiling `DoubleFloats`, I'm getting this warning:

```
Julia-1.6.1> using DoubleFloats
[ Info: Precompiling DoubleFloats [497a8b3b-efae-58df-a0af-a86822472b78]
WARNING: could not import Printf.ini_hex into DoubleFloats
WARNING: could not import Printf.ini_HEX into DoubleFloats
```

Firstly, I don't really understand this code.

But it seems `ini_hex` and `ini_HEX` are not used in this file (`src/type/show.jl`).

Also it seems `Printf` no longer uses `ini_hex` and `ini_HEX`.
I think they were removed in "Rewrite printf functionality" [#32859](https://github.com/JuliaLang/julia/pull/32859)