### PR TITLE
support specialfunctions 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Polynomials = "1, 2"
 Quadmath = "0.4, 0.5, 0.6"
 Requires = "1"
-SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1.0, 1.1"
+SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1.0, 1.1, 2"
 GenericLinearAlgebra = "0.2.5, 0.3, 0.4, 0.5, 0.6"
 julia = "1"
 


### PR DESCRIPTION
The only breaking change in SpecialFunctions 2.0 [was deleting](https://github.com/JuliaMath/SpecialFunctions.jl/pull/297) the `factorial(x::Real) = gamma(x+1)` function, and since you don't use `factorial` this shouldn't affect you.