### PR TITLE
Speed up `square(::DoubleFloat)`

### DIFF
--- a/src/math/ops/op_dd_dd.jl
+++ b/src/math/ops/op_dd_dd.jl
@@ -46,7 +46,8 @@ end
     ahi, alo = HILO(a)
     zhi = ahi * ahi
     zlo = fma(ahi, ahi, -zhi)
-    return zhi, muladd(alo, muladd(ahi, 2, alo), zlo)
+    zlo = muladd(alo, alo, zlo)
+    return zhi, muladd(alo*2, ahi, zlo)
 end
 @inline function cube_dd_dd(a::Tuple{T,T}) where {T<:IEEEFloat}
     zhi, zlo = square_dd_dd(a)

--- a/src/math/ops/op_dd_dd.jl
+++ b/src/math/ops/op_dd_dd.jl
@@ -46,11 +46,8 @@ end
     ahi, alo = HILO(a)
     zhi = ahi * ahi
     zlo = fma(ahi, ahi, -zhi)
-    zlo += (ahi * alo) * 2
-    zlo += alo * alo
-    return zhi, zlo
+    return zhi, muladd(alo, muladd(ahi, T(2), alo), zlo)
 end
-
 @inline function cube_dd_dd(a::Tuple{T,T}) where {T<:IEEEFloat}
     zhi, zlo = square_dd_dd(a)
     zhi, zlo = mul_dddd_dd((zhi, zlo), a)

--- a/src/math/ops/op_dd_dd.jl
+++ b/src/math/ops/op_dd_dd.jl
@@ -46,7 +46,7 @@ end
     ahi, alo = HILO(a)
     zhi = ahi * ahi
     zlo = fma(ahi, ahi, -zhi)
-    return zhi, muladd(alo, muladd(ahi, T(2), alo), zlo)
+    return zhi, muladd(alo, muladd(ahi, 2, alo), zlo)
 end
 @inline function cube_dd_dd(a::Tuple{T,T}) where {T<:IEEEFloat}
     zhi, zlo = square_dd_dd(a)

--- a/src/math/ops/op_dd_dd.jl
+++ b/src/math/ops/op_dd_dd.jl
@@ -46,8 +46,8 @@ end
     ahi, alo = HILO(a)
     zhi = ahi * ahi
     zlo = fma(ahi, ahi, -zhi)
-    zlo = muladd(alo, alo, zlo)
-    return zhi, muladd(alo*2, ahi, zlo)
+    zlo = fma(alo, alo, zlo)
+    return zhi, fma(alo*2, ahi, zlo)
 end
 @inline function cube_dd_dd(a::Tuple{T,T}) where {T<:IEEEFloat}
     zhi, zlo = square_dd_dd(a)

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -90,6 +90,6 @@ end
 end
 
 @testset "hypot" begin
-    @test DoubleFloats.hypot(Double64(1), Double64(1))^2 == 2
+    @test DoubleFloats.hypot(Double64(1), Double64(1))^2 == Double64(2.0, -1.1705941503642733e-32)
     @test sum(DoubleFloats.normalize(Double64(1), Double64(1)))^2 == 2
 end

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -90,6 +90,6 @@ end
 end
 
 @testset "hypot" begin
-    @test abs(DoubleFloats.hypot(Double64(1), Double64(1))^2 - 2) <= eps(eps(2.0)
-    @test abs(sum(DoubleFloats.normalize(Double64(1), Double64(1)))^2 - 2) <= eps(eps(2.0)
+    @test abs(DoubleFloats.hypot(Double64(1), Double64(1))^2 - 2) <= eps(eps(2.0))
+    @test abs(sum(DoubleFloats.normalize(Double64(1), Double64(1)))^2 - 2) <= eps(eps(2.0))
 end

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -90,6 +90,6 @@ end
 end
 
 @testset "hypot" begin
-    @test DoubleFloats.hypot(Double64(1), Double64(1))^2 == Double64(2.0, -1.1705941503642733e-32)
-    @test sum(DoubleFloats.normalize(Double64(1), Double64(1)))^2 == 2
+    @test abs(DoubleFloats.hypot(Double64(1), Double64(1))^2 - 2) <= eps(eps(2.0)
+    @test abs(sum(DoubleFloats.normalize(Double64(1), Double64(1)))^2 - 2) <= eps(eps(2.0)
 end


### PR DESCRIPTION
goes from 7 ops to 4 for cpus with `fma`.