### PR TITLE
Fixes #128

### DIFF
--- a/src/extras/misc.jl
+++ b/src/extras/misc.jl
@@ -62,3 +62,9 @@ end
 function Base.:(-)(m::Matrix{DoubleFloat{T}}, x::T) where {T}
     return m .- x
 end
+
+# for getting fast floatmin2, used in Givens rotations in LinearAlgebra
+# these values were computed with the existing code saved
+# floatmin2(::Type{T}) where {T} = (twopar = 2one(T); twopar^trunc(Integer,log(floatmin(T)/eps(T))/log(twopar)/twopar))
+LinearAlgebra.floatmin2(::Type{Double64}) = Double64(reinterpret(Float64, 0x2350000000000000), 0.0)
+LinearAlgebra.floatmin2(::Type{Double32}) = Double32(reinterpret(Float32, 0x2c000000), 0.0f0)

--- a/src/extras/misc.jl
+++ b/src/extras/misc.jl
@@ -68,3 +68,4 @@ end
 # floatmin2(::Type{T}) where {T} = (twopar = 2one(T); twopar^trunc(Integer,log(floatmin(T)/eps(T))/log(twopar)/twopar))
 LinearAlgebra.floatmin2(::Type{Double64}) = Double64(reinterpret(Float64, 0x2350000000000000), 0.0)
 LinearAlgebra.floatmin2(::Type{Double32}) = Double32(reinterpret(Float32, 0x2c000000), 0.0f0)
+LinearAlgebra.floatmin2(::Type{Double16}) = Double16(Float16(8.0), Float16(0.0))

--- a/test/specialvalues.jl
+++ b/test/specialvalues.jl
@@ -61,3 +61,8 @@ end
     @test isnan(asech(T(NaN)))
     @test isnan(acoth(T(NaN)))
 end
+    
+@testset "floatmin2" for T in (Double16, Double32, Double64)
+    trueval = (twopar = 2one(T); twopar^trunc(Integer,log(floatmin(T)/eps(T))/log(twopar)/twopar))
+    @test LinearAlgebra.floatmin2(T) == trueval 
+end         

--- a/test/specialvalues.jl
+++ b/test/specialvalues.jl
@@ -62,7 +62,7 @@ end
     @test isnan(acoth(T(NaN)))
 end
     
-@testset "floatmin2" for T in (Double16, Double32, Double64)
+@testset "floatmin2 $T" for T in (Double16, Double32, Double64)
     trueval = (twopar = 2one(T); twopar^trunc(Integer,log(floatmin(T)/eps(T))/log(twopar)/twopar))
     @test LinearAlgebra.floatmin2(T) == trueval 
 end         


### PR DESCRIPTION
This adds specializations for LinearAlgebra.floatmin2 for Double16, Double32, and Double64 and fixes #128 