### PR TITLE
use `compact=false` by default when printing.

### DIFF
--- a/src/type/show.jl
+++ b/src/type/show.jl
@@ -4,7 +4,7 @@ show(io::IO, ::Type{Double64}) = print(io, "Double64")
 show(io::IO, ::Type{Double32}) = print(io, "Double32")
 
 function show(io::IO, x::DoubleFloat{T}) where {T<:IEEEFloat}
-    compact = get(io, :compact, true)
+    compact = get(io, :compact, false)
     if compact
         str = string(x.hi)
     else
@@ -16,7 +16,7 @@ end
 function show(io::IO, x::Complex{DoubleFloat{T}}) where {T<:IEEEFloat}
     re, im = reim(x)
     imstr = isfinite(im) ? "im" : "*im"
-    compact = get(io, :compact, true)
+    compact = get(io, :compact, false)
     if compact
         str = string(HI(re), (signbit(x.im.hi) ? " - " : " + "), abs(HI(im)), imstr)
     else

--- a/test/string.jl
+++ b/test/string.jl
@@ -1,10 +1,19 @@
+function test_string_and_show(x, s)
+  b = IOBuffer
+  show(b, x)
+  @test String(take!(b)) == string(x) == s
+end
+
 @testset "string" begin
+  test_string_and_show(Double64(pi), "3.14159265358979323846264338327950588")
 
-  @test string(Double64(pi)) == "3.14159265358979323846264338327950588"
-
-  @test string(Double64(2.3045377697175683e-24, -1.5436846311151439e-40)) == "2.30453776971756809999999999999975586e-24"
+  x = Double64(2.3045377697175683e-24, -1.5436846311151439e-40)
+  test_string_and_show(x, "2.30453776971756809999999999999975586e-24")
   
-  @test string(ComplexDF64(1.0,1.0)) == "1.0 + 1.0im"
+  test_string_and_show(ComplexDF64(1.0,1.0), "1.0 + 1.0im")
+
+  x = Complex{Double64}(pi)+Double64(pi)*im
+  test_string_and_show(x, "3.14159265358979323846264338327950588 + 3.14159265358979323846264338327950588im")
 
   @test stringtyped(Double64(pi)) == "Double64(3.141592653589793, 1.2246467991473532e-16)"
 

--- a/test/string.jl
+++ b/test/string.jl
@@ -1,5 +1,5 @@
 function test_string_and_show(x, s)
-  b = IOBuffer
+  b = IOBuffer()
   show(b, x)
   @test String(take!(b)) == string(x) == s
 end


### PR DESCRIPTION
When doing complex calculations with `DoubleFloat`s it is often really nice to have these extra digits to reassure you that you didn't accidentally lose precision from an accidental `Float64` cast. This will make display slower, but I think it's completely worth it (especially since the compact show can show incorrect decimal digits. For example
```
julia> x=Double64(big(1)+5e-16)
1.00000000000000050000000000000003885

julia> x.hi
1.0000000000000004
```