### PR TITLE
doc: fix doc style and link

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -136,7 +136,7 @@ Usage questions can be posted on the [Julia Discourse forum](https://discourse.j
 
 ## Contributions
 
-Contributions are very welcome, as are feature requests and suggestions. Please open an [issue](https://github.com/JuliaMath/DoubleFloats.jl/issues) if you encounter any problems. The [contributing page](https://juliamath.github.io/DoubleFloats.jl/latest/man/contributing/) has a few guidelines that should be followed when opening pull requests.
+Contributions are very welcome, as are feature requests and suggestions. Please open an [issue](https://github.com/JuliaMath/DoubleFloats.jl/issues) if you encounter any problems. The [contributing page](https://juliamath.github.io/DoubleFloats.jl/latest/#Contributions) has a few guidelines that should be followed when opening pull requests.
 
 ----
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,7 +3,7 @@
 ### Math with 85+ accurate bits.
 #### Extended precision float and complex types
 
-- N.B. `Double64` is the most performant type <sup>[β](#involvement)</sup>
+- N.B. `Double64` is the most performant type [^β]
 
 ----
 
@@ -140,8 +140,6 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 
 ----
 
-<a name="involvement">β</a>: If you want to get involved with moving `Double32` performance forward, great. I would provide guidance. Otherwise, for most purposes you are better off using `Float64` than `Double32` (`Float64` has more significant bits, wider exponent range, and is much faster).
+[^β]: If you want to get involved with moving `Double32` performance forward, great. I would provide guidance. Otherwise, for most purposes you are better off using `Float64` than `Double32` (`Float64` has more significant bits, wider exponent range, and is much faster).
 
 ----
-
-

--- a/docs/src/linearalgebra.md
+++ b/docs/src/linearalgebra.md
@@ -14,7 +14,7 @@ using DoubleFloats, LinearAlgebra
 n = 25
 vector = rand(Double64, n)
 matrix = reshape(rand(Double64,n*n),n,n)
-
+```
 
 ## Matrix Predicates
 
@@ -54,5 +54,3 @@ matrix = reshape(rand(Double64,n*n),n,n)
 - `asinh`, `acosh`, `atanh`, `acsch`, `asech`, `acoth`
 
 - matrixfunction(function, matrix)
-
-


### PR DESCRIPTION
- footnote
![image](https://user-images.githubusercontent.com/5158738/221597704-7a202cac-f216-41d5-ba29-da975b1f6f99.png)
![image](https://user-images.githubusercontent.com/5158738/221597810-5d662944-24fb-46ee-946d-0692ee3b6b87.png)

- code block
![image](https://user-images.githubusercontent.com/5158738/221598019-834c8373-d488-4e19-b2f4-94482222ae52.png)

Note: When I tested locally, I used the default document theme, so the background is black.

