### PR TITLE
remove type piracy from show of `DoubleFloat` types

### DIFF
--- a/src/type/show.jl
+++ b/src/type/show.jl
@@ -1,8 +1,5 @@
 import Printf: ini_dec, fix_dec
 
-show(io::IO, ::Type{Double64}) = print(io, "Double64")
-show(io::IO, ::Type{Double32}) = print(io, "Double32")
-
 function show(io::IO, x::DoubleFloat{T}) where {T<:IEEEFloat}
     compact = get(io, :compact, false)
     if compact


### PR DESCRIPTION
Overloading `show` on `Type` causes a huge number of invalidations and shouldn't really be done.