### PR TITLE
Fix `Base.precision` on Julia v1.11

### DIFF
--- a/src/Double.jl
+++ b/src/Double.jl
@@ -213,8 +213,8 @@ DoubleFloat(x::Int64) = Double64(x, zero(Int64))
 DoubleFloat(x::Int32) = Double32(x, zero(Int32))
 DoubleFloat(x::Int16) = Double16(x, zero(Int16))
 
-# overload Base._precision to support the base keyword in Julia 1.8
-let precision = isdefined(Base, :_precision) ? :_precision : :precision
+# overload Base._precision_with_base_2 or Base._precision to support the base keyword in Julia 1.8
+let precision = isdefined(Base, :_precision_with_base_2) ? :_precision_with_base_2 : isdefined(Base, :_precision) ? :_precision : :precision
     @eval Base.$precision(::Type{DoubleFloat{T}}) where {T<:IEEEFloat} = 2*Base.$precision(T)
 end
 


### PR DESCRIPTION
A recent [bugfix on Julia master](https://github.com/JuliaLang/julia/pull/52910) renamed `Base._precision(T)` (without a second `base` argument) to `Base._precision_with_base_2(T)`, which broke `precision(Double64)`. This PR patches that.

Before this PR:

```julia
julia-1.10.0> using DoubleFloats

julia-1.10.0> precision(Double64)
106
```

```julia
julia-1.11.0-DEV.1459> precision(Double64)
ERROR: MethodError: no method matching _precision_with_base_2(::Type{Double64})

Closest candidates are:
  _precision_with_base_2(::BigFloat)
   @ Base mpfr.jl:957
  _precision_with_base_2(::Type{BigFloat})
   @ Base mpfr.jl:962
  _precision_with_base_2(::Type{Float64})
   @ Base float.jl:841
  ...

Stacktrace:
 [1] _precision(x::Type, base::Int64)
   @ Base ./float.jl:844
 [2] precision(::Type{Double64}; base::Int64)
   @ Base ./float.jl:847
 [3] precision(::Type{Double64})
   @ Base ./float.jl:847
 [4] top-level scope
   @ REPL[1]:1
```

After this PR:

```julia
julia-1.11.0-DEV.1459> using DoubleFloats

julia-1.11.0-DEV.1459> precision(Double64)
106
```