### PR TITLE
add logabsgamma and unrelated fixes

### DIFF
--- a/src/math/ops/op_dd_dd.jl
+++ b/src/math/ops/op_dd_dd.jl
@@ -56,7 +56,7 @@ end
 end
 
 function sqrt_dd_dd(x::Tuple{T,T}) where {T<:IEEEFloat}
-    iszero(HI(x))) && return x
+    iszero(HI(x)) && return x
     signbit(HI(x)) && throw(DomainError("sqrt(x) expects x >= 0"))   # maybe we can remove this check? It will return nan anyway.
 
     ahi, alo = HILO(x)

--- a/src/math/special/gamma_erf.jl
+++ b/src/math/special/gamma_erf.jl
@@ -15,3 +15,11 @@ erfc(x::Double16) = Double16Float128(erfc, x)
 gamma(x::Double16) = Double16Float128(gamma, x)
 lgamma(x::Double16) = Double16Float128(lgamma, x)
 loggamma(x::Double16) = Double16Float128(lgamma, x)
+
+function logabsgamma(x::DoubleFloat{T}) where {T<:IEEEFloat}
+    keep_precision = precision(BigFloat)
+    setprecision(BigFloat, 128)
+    result = logabsgamma(BigFloat(x))
+    setprecision(BigFloat, keep_precision)
+    return DoubleFloat{T}(result[1]), result[2]
+end

--- a/src/math/special/specialfunctions.jl
+++ b/src/math/special/specialfunctions.jl
@@ -1,6 +1,7 @@
 import .SpecialFunctions
-import .SpecialFunctions: erf, erfc, gamma, lgamma,
-    besselj0, besselj1, besselj, bessely0, bessely1, bessely
+import .SpecialFunctions: erf, erfc, gamma, lgamma, loggamma, logabsgamma,
+    besselj0, besselj1, besselj, bessely0, bessely1, bessely,
+    ellipk
 
 include("agm.jl")
 include("bessel.jl")


### PR DESCRIPTION
Fixes #183 

Also fixed the shadowing functions, it turned out that the syntax was correct, but `loggamma` and `ellipk` were missing from `specialfunctions.jl`.

And also fixed an unrelated typo in `sqrt_dd_dd` that was preventing compilation.