### PR TITLE
Fix conversion from Inf

### DIFF
--- a/src/Double.jl
+++ b/src/Double.jl
@@ -105,7 +105,7 @@ Convert `x` to an extended precision `Double64`.
         lo = Float64(x - Float64(hi))
     else
         hi = Float64(x)
-        lo = NaN
+        lo = hi
     end
     return Double64(hi, lo)
 end
@@ -120,7 +120,7 @@ Convert `x` to an extended precision `Double32`.
         lo = Float32(x - Float32(hi))
     else
         hi = Float32(x)
-        lo = NaN32
+        lo = hi
     end
     return Double32(hi, lo)
 end
@@ -136,7 +136,7 @@ Convert `x` to an extended precision `Double16`.
         lo = Float16(x - Float16(hi))
     else
         hi = Float16(x)
-        lo = NaN16
+        lo = hi
     end
     return Double16(hi, lo)
 end

--- a/test/specialvalues.jl
+++ b/test/specialvalues.jl
@@ -33,6 +33,21 @@ end
     @test isnan(LO(T(NaN)))
 end
 
+@testset "Inf and NaN conversion" for T in (Double16, Double32, Double64)
+    for S in (BigFloat, Float128)
+        @test isnan(S(T(NaN)))
+        @test isinf(S(T(Inf)))
+        @test S(T(Inf)) > 0
+        @test isinf(S(T(-Inf)))
+        @test S(T(-Inf)) < 0
+        @test isnan(T(S(NaN)))
+        @test isinf(T(S(Inf)))
+        @test T(S(Inf)) > 0
+        @test isinf(T(S(-Inf)))
+        @test T(S(-Inf)) < 0
+    end
+end
+
 @testset "NaNs $T" for T in (Double16, Double32, Double64)
     @test isnan(exp(T(NaN)))
     @test isnan(log(T(NaN)))

--- a/test/specialvalues.jl
+++ b/test/specialvalues.jl
@@ -29,7 +29,7 @@ end
 @testset "Inf and NaN layout $T" for T in (Double16, Double32, Double64)
     @test isinf(HI(T(Inf)))
     @test isnan(HI(T(NaN)))
-    @test isnan(LO(T(Inf)))
+    @test isinf(LO(T(Inf)))
     @test isnan(LO(T(NaN)))
 end
 


### PR DESCRIPTION
Currently `BigFloat(Double64(Inf))` and `Float128(Double64(Inf))` return `NaN`, this PR fixes it.