### PR TITLE
make multiplication commutative

### DIFF
--- a/src/math/ops/op_dddd_dd.jl
+++ b/src/math/ops/op_dddd_dd.jl
@@ -25,14 +25,14 @@ end
     return hi, lo
 end
 
-# Algorithm 12 from Tight and rigourous error bounds.  relative error <= 5u²
+# Algorithm 10 from Tight and rigourous error bounds.  relative error <= 7u²
 @inline function mul_dddd_dd(x::Tuple{T,T}, y::Tuple{T,T}) where T<:IEEEFloat
     xhi, xlo = x
     yhi, ylo = y
     hi, lo = two_prod(xhi, yhi)
-    t = xlo * ylo
-    t = fma(xhi, ylo, t)
-    t = fma(xlo, yhi, t)
+    t1 = xhi * ylo
+    t2 = xlo * yhi
+    t = t1 + t2
     t = lo + t
     hi, lo = two_hilo_sum(hi, t)
     return hi, lo

--- a/test/concrete_accuracy.jl
+++ b/test/concrete_accuracy.jl
@@ -8,7 +8,7 @@
     @test pi_accurate   == DoubleFloat{Float64}(pi)
 
     @test abs(inv(inv(pi_accurate)) - pi_accurate) <= eps(LO(pi_accurate))
-    @test abs(phi_accurate - (phi_accurate*phi_accurate - 1.0)) <= eps(LO(phi_accurate))
+    @test abs(phi_accurate - (phi_accurate*phi_accurate - 1.0)) <= 3eps(LO(phi_accurate))
 
     a = Base.TwicePrecision(3.0) / Base.TwicePrecision(7.0)
     b = Double64(3.0) / Double64(7.0)


### PR DESCRIPTION
Closes #161

This changes from algorithm 12 to algorithm 10, causing a slight loss of precision in order to gain commutativity. I think it's worth it; of course, you might disagree. In this case feel free to close the PR, no hard feelings.