### PR TITLE
widen compat bounds and cleanup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,15 +15,14 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-GenericLinearAlgebra = "0.4 - 0.6"
-Quadmath = "1"
+GenericLinearAlgebra = "0.3 - 0.6"
+Quadmath = "0.5 - 1"
 SpecialFunctions = "1 - 2"
 julia = "1.10"
 
 [extras]
-GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
 GenericSchur = "c145ed77-6b09-5dd9-b285-bf645a82121e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "GenericLinearAlgebra", "GenericSchur"]
+test = ["Test", "GenericSchur"]

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 GenericLinearAlgebra = "0.3 - 0.6"
-Quadmath = "0.5 - 1"
+Quadmath = "1"
 SpecialFunctions = "1 - 2"
 julia = "1.10"
 

--- a/src/DoubleFloats.jl
+++ b/src/DoubleFloats.jl
@@ -77,13 +77,8 @@ import Base.Math: modf, fma, muladd,
              asin, acos, atan, acsc, asec, acot,
              sinh, cosh, tanh, csch, sech, coth,
              asinh, acosh, atanh, acsch, asech, acoth,
-             sinpi, cospi, sincos, sincospi, cis, cispi
-
-@static if VERSION >= v"1.10.0"
-    import Base.Math: tanpi 
-else
-    export tanpi 
-end       
+             sinpi, cospi, tanpi,
+             sincos, sincospi, cis, cispi
 
 import Quadmath: Float128
 

--- a/src/type/predicates.jl
+++ b/src/type/predicates.jl
@@ -136,8 +136,3 @@ iseven(x::DoubleFloat{T}) where {T<:IEEEFloat} =
     else
         false
     end
-
-if VERSION < v"1.7"
-    iseven(x::AbstractFloat) = isinteger(x) && (abs(x) > maxintfloat(x) || iseven(Integer(x)))
-    isodd(x::AbstractFloat) = isinteger(x) && abs(x) ≤ maxintfloat(x) && isodd(Integer(x))
-end

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -42,10 +42,6 @@ d64b = sqrt(Double64(2.0))/2
    @test isapprox(expm1(f64a), expm1(d64a))    
 end
 
-if VERSION < v"1.10"
-    DoubleFloats.tanpi(x::T) where {T<:IEEEFloat} = T(tanpi(DoubleFloat{T}(x)))
-end
-
 @testset "trig functions" begin
     for d64 in (-Double64(4),-Double64(3)/10, Double64(3)/10, d64a, d64b, Double64(4))
         f64 = Float64(d64)


### PR DESCRIPTION
I think it will cause less trouble to keep accepting `GenericLinearAlgebra` 0.3 and `Quadmath` 0.5, nothing breaking was done. Also, took the opportunity to cleanup some version switches.