### PR TITLE
Correctly handle zero and nonfinite values in DoubleFloat `inv`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["math", "floating-point", "doubledouble", "extended-precision", "acc
 license = "MIT"
 desc = "extended precision floating point types using value pairs"
 repo = "https://github.com/JuliaMath/DoubleFloats.jl.git"
-version = "1.9.1"
+version = "1.9.2"
 
 [deps]
 GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"

--- a/src/math/ops/op_db_db.jl
+++ b/src/math/ops/op_db_db.jl
@@ -1,7 +1,9 @@
 @inline function inv_db_db(x::DoubleFloat{T}) where {T<:IEEEFloat}
     yhi, ylo = x.hi, x.lo
     thi = inv(yhi)
-    (!isfinite(thi) || iszero(ylo) || !isfinite(ylo)) &&
+    # See the comment on inv_dd_dd: ylo == 0 must not short-circuit, or inv loses
+    # the low word for every exactly-representable argument (e.g. inv(Double64(3))).
+    (!isfinite(thi) || !isfinite(yhi) || !isfinite(ylo)) &&
         return DoubleFloat{T}(zero_error_result(thi)...)
     zhi, zlo = unsafe_inv_dd_dd_(yhi, ylo)
     isfinite(zhi) || return DoubleFloat{T}(unsafe_inv_dd_dd(yhi, ylo)...)

--- a/src/math/ops/op_dd_dd.jl
+++ b/src/math/ops/op_dd_dd.jl
@@ -1,8 +1,16 @@
 # inv corrected to handle zero and nonfinite values
+# - !isfinite(tₕᵢ) catches yₕᵢ == ±0 and reciprocals that overflow (issue #278),
+#   where the residual fma below would produce NaNs.
+# - !isfinite(yₕᵢ) catches yₕᵢ == ±Inf and NaN, whose reciprocals (±0, NaN) are
+#   not caught by the first test.
+# Note that yₗₒ == 0 must NOT short-circuit: the residual fma in unsafe_inv_dd_dd
+# captures the rounding error of inv(yₕᵢ) itself, so returning zero_error_result
+# would discard the low word entirely — e.g., inv(Double64(3)) would be accurate
+# only to Float64 precision.
 @inline function inv_dd_dd(y::Tuple{T, T}) where {T<:IEEEFloat}
    yₕᵢ, yₗₒ = y
     tₕᵢ = inv(yₕᵢ)
-    if !isfinite(tₕᵢ) || iszero(yₗₒ) || !isfinite(yₗₒ)
+    if !isfinite(tₕᵢ) || !isfinite(yₕᵢ) || !isfinite(yₗₒ)
           zero_error_result(tₕᵢ)
    else
       unsafe_inv_dd_dd(yₕᵢ, yₗₒ)

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -50,8 +50,32 @@ end
 
 @testset "inv corner cases" begin
     @test inv(Double64(0.0)) == Double64(Inf)
+    @test inv(Double64(-0.0)) == Double64(-Inf)
     @test inv(Double64(Inf)) == Double64(0.0)
+    @test inv(Double64(-Inf)) == Double64(0.0)
+    @test signbit(inv(Double64(-Inf)))
+    @test isnan(inv(Double64(NaN)))
     @test inv(Double64(1.0e-310)) == Double64(Inf)
+end
+
+# n = number of significand bits in the underlying float type
+@testset "inv full precision when LO(x) == 0, $D" for (D, n) in
+        ((Double64, 53), (Double32, 24), (Double16, 11))
+    # `inv` must capture the rounding error of `inv(HI(x))` in the low word, even
+    # when LO(x) == 0 — i.e., for every exactly-representable argument, such as
+    # ordinary integers.  An early version of the nonfinite-value handling above
+    # returned a zero low word for all such arguments, silently reducing `inv` to
+    # the precision of the underlying float type.
+    setprecision(BigFloat, 512) do
+        for k in (3, 5, 6, 7, 9, 10, 11, 49, 1.5)
+            x = D(k)
+            @test iszero(LO(x))  # otherwise this test exercises nothing
+            relerr = abs(BigFloat(inv(x)) - inv(BigFloat(x))) * BigFloat(x)
+            @test relerr < BigFloat(2)^(-2n + 2)  # full double-word precision
+        end
+        # The reciprocal of a power of two is exact.
+        @test inv(D(4)) == D(1) / D(4) == D(0.25)
+    end
 end
 
 @testset "Trig functions" begin


### PR DESCRIPTION
Closes #285

Tests added for the reported issue, and a few extra corner cases for good measure.