### PR TITLE
Unbump version to 1.9.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["math", "floating-point", "doubledouble", "extended-precision", "acc
 license = "MIT"
 desc = "extended precision floating point types using value pairs"
 repo = "https://github.com/JuliaMath/DoubleFloats.jl.git"
-version = "1.9.3"
+version = "1.9.2"
 
 [deps]
 GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"


### PR DESCRIPTION
Fully drive-by. I happened to notice this version bump got stuck over at https://github.com/JuliaRegistries/General/pull/158936#issuecomment-4781401072